### PR TITLE
Updates readme.md with a note about charging with set limit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ SUBCOMMANDS:
   See 'bclm help <subcommand>' for detailed help.
 ```
 
-When writing values, macOS charges slightly beyond the set value (~3%). In order to display 80% when fully charged, it is recommended to set the BCLM value to 77%.
+When writing values, macOS charges slightly beyond the set value (~3%). In order to display 80% when fully charged, it is recommended to set the BCLM value to 77%. When charging while system is shut down or sleeping, the charging can go beyond set value more than average 3%.
 
 ```
 $ sudo bclm write 77


### PR DESCRIPTION
Charging cycle can go much further than bclm set value. For an instance, setting 77 would charge battery when system is up and running to about 80%. When same system is shut down or put in sleep, charging can go up to 91% but mostly up to 89% with same setting of 77. This is tested on MacBook Air (2017) with macOS Monterey v. 12.6.2 (21G320). This is happens even if you set persist value.