### PR TITLE
Create /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ sudo make install
 
 ```
 $ unzip bclm.zip
+$ sudo mkdir -p /usr/local/bin
 $ sudo cp bclm /usr/local/bin
 ```
 


### PR DESCRIPTION
Create /usr/local/bin prior to running the copy command. If `bin` does not exist, you are actually moving `bclm` to `/usr/local/` and renaming `bclm` to `bin`. -a mistake I just made :)

Closes #34