### PR TITLE
Add loop/persist-loop command

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,6 +4,7 @@
 name: Swift
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:

--- a/Sources/bclm/main.swift
+++ b/Sources/bclm/main.swift
@@ -206,6 +206,7 @@ struct BCLM: ParsableCommand {
                         try SMCKit.writeData(bclm_key, data: bclm_bytes_unlimit)
                         try SMCKit.writeData(aclc_key, data: aclc_bytes_unknown)
                     }
+                    SMCKit.close()
                 } catch {
                     print(error)
                 }

--- a/Sources/bclm/main.swift
+++ b/Sources/bclm/main.swift
@@ -210,7 +210,7 @@ struct BCLM: ParsableCommand {
                             try SMCKit.writeData(bclm_key, data: bclm_bytes_unlimit)
                             try SMCKit.writeData(aclc_key, data: aclc_bytes_charging)
                             if (pmStatus == nil) {
-                                pmStatus = IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleSystemSleep as CFString, UInt32(kIOPMAssertionLevelOn), reasonForActivity as CFString, &assertionID)
+                                pmStatus = IOPMAssertionCreateWithName(kIOPMAssertionTypePreventSystemSleep as CFString, UInt32(kIOPMAssertionLevelOn), reasonForActivity as CFString, &assertionID)
                                 if (pmStatus != kIOReturnSuccess) {
                                     pmStatus = nil
                                     assertionID = IOPMAssertionID(0)

--- a/Sources/bclm/main.swift
+++ b/Sources/bclm/main.swift
@@ -211,7 +211,7 @@ struct BCLM: ParsableCommand {
                                     pmStatus = nil
                                     assertionID = IOPMAssertionID(0)
                                 }
-                            } else {
+                            } else if (currentBattLevelInt < 78) {
                                 try SMCKit.writeData(bclm_key, data: bclm_bytes_unlimit)
                                 isCharging = true
 

--- a/Sources/bclm/main.swift
+++ b/Sources/bclm/main.swift
@@ -146,7 +146,6 @@ struct BCLM: ParsableCommand {
         }
         
         func run() {
-            var lastStatus = "Unknown"
             let aclc_key = SMCKit.getKey("ACLC", type: DataTypes.UInt8)
             let aclc_bytes_full: SMCBytes = (
                 UInt8(3), UInt8(0), UInt8(0), UInt8(0), UInt8(0), UInt8(0),
@@ -179,28 +178,17 @@ struct BCLM: ParsableCommand {
                 let currentBattLevelInt = Int(currentBattLevel ?? -1)
                 
                 do {
+                    try SMCKit.open()
                     if (isCharging && currentBattLevelInt != -1) {
-                        if (currentBattLevelInt >= 80) {
-                            if (lastStatus != "Full") {
-                                lastStatus = "Full" // Maybe.
-                                try SMCKit.open()
-                                try SMCKit.writeData(aclc_key, data: aclc_bytes_full)
-                            }
-                        } else if (lastStatus != "Charging") {
-                            lastStatus = "Charging"
-                            try SMCKit.open()
-                            try SMCKit.writeData(aclc_key, data: aclc_bytes_charging)
-                        }
-                    } else if (lastStatus != "Unknown") {
-                        lastStatus = "Unknown"
-                        try SMCKit.open()
+                        try SMCKit.writeData(aclc_key, data: (currentBattLevelInt >= 80 ? aclc_bytes_full : aclc_bytes_charging))
+                    } else {
                         try SMCKit.writeData(aclc_key, data: aclc_bytes_unknown)
                     }
                 } catch {
                     print(error)
                 }
 
-                sleep(1)
+                sleep(2)
             }
         }
     }

--- a/Sources/bclm/main.swift
+++ b/Sources/bclm/main.swift
@@ -193,7 +193,7 @@ struct BCLM: ParsableCommand {
                 let sources = IOPSCopyPowerSourcesList(snapshot).takeRetainedValue() as Array
                 let chargeState = sources[0]["Power Source State"] as? String
                 let isACPower = (chargeState == "AC Power") ? true : false
-                var isCharging = sources[0]["Is Charging"] as? Bool
+                let isCharging = sources[0]["Is Charging"] as? Bool
                 let currentBattLevelInt = Int((sources[0]["Current Capacity"] as? Int) ?? -1)
                 
                 do {
@@ -204,7 +204,6 @@ struct BCLM: ParsableCommand {
                         if (isACPower)  {
                             if (currentBattLevelInt >= 80) {
                                 try SMCKit.writeData(bclm_key, data: bclm_bytes_limit)
-                                isCharging = false
 
                                 // The battery is "full", so sleep will no longer be prevented (If currently prevented).
                                 if (pmStatus != nil && IOPMAssertionRelease(assertionID) == kIOReturnSuccess) {
@@ -213,7 +212,6 @@ struct BCLM: ParsableCommand {
                                 }
                             } else if (currentBattLevelInt < 78) {
                                 try SMCKit.writeData(bclm_key, data: bclm_bytes_unlimit)
-                                isCharging = true
 
                                 // The battery is not "full", so sleep will be prevented (If not currently prevented).
                                 if (pmStatus == nil) {


### PR DESCRIPTION
I've never written Swift code so the code is obviously not very good.

By adding the loop command, you can run it as a background service and change the status of the indicator light by polling the battery information.
The new persist-loop command will add a background service that runs the loop command specifically for changing the Magsafe LED.

It will turn the light green when the charge is greater than 80%, on Apple Silicon I'm assuming this is no problem.
I don't know if multiple programs can open SMC at the same time, so I only initiate the open request when calling.

Tested on my M1 Pro Mac and it works.

Issue: https://github.com/zackelia/bclm/issues/31
Refer:
https://github.com/actuallymentor/battery/pull/163 (CHWA)
https://github.com/actuallymentor/battery/issues/71 / https://github.com/actuallymentor/battery/blob/0c48dc054338257ffaf4087f0e61e2ab1a2037f6/battery.sh#L447 (ACLC)

Edit: Looks like it still has some issues, I'll look into it. Well, it looks like we can't store the last state to save resources, as this makes the run unreliable due to latency.

One question is, if we run it as a background service, how can we enable users to switch charging capacity without restarting? My idea is: for loops, it would be better to create a file that marks the set capacity (or switch), but I'm not sure where to put the file.

Added. Ref:  https://github.com/AsahiLinux/linux/blob/107ed86e21d1522d5d5d9d629f1d9c371e37df7f/drivers/power/supply/macsmc_power.c#L79 ~~Another question is whether we need a range to prevent frequent 79% to 80% charging~~