### PR TITLE
Create bindir if it does not exist in the install rule 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build:
 	strip .build/apple/Products/Release/bclm
 
 install: build
+	mkdir -p "$(bindir)"
 	install ".build/apple/Products/Release/bclm" "$(bindir)"
 
 uninstall:


### PR DESCRIPTION
Fixes issue #45 